### PR TITLE
Require pango on macOS as well as Linux

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ requirements:
     - libtool                  # [linux]
     - freetype                 # [unix]
     - jpeg                     # [unix]
-    - pango                    # [linux]
+    - pango                    # [unix]
     - zlib                     # [unix]
     - libxcb                   # [linux]
     - xorg-libxrender          # [linux]


### PR DESCRIPTION
See #35 and #50.